### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-01-11
+
+### Changed
+
+#### Architecture
+- Refactored Python utilities into shared `_utils.py` module for code deduplication
+- Introduced `TypeCategory` enum for centralized HANA type classification
+- Added `NonZeroUsize` for type-safe batch size configuration
+- Implemented `RowLike` trait abstraction for testing without HANA connection
+- Added `MockRow`/`MockRowBuilder` test utilities (behind `test-utils` feature flag)
+- Created `impl_field_metadata_ext!` macro for DRY trait implementations
+
+#### Testing
+- Added comprehensive unit tests for `_utils.py` module (25 tests)
+- Improved test coverage for PyO3 bindings
+- Added pytest tests for module imports, exceptions, and DB-API types
+
+#### CI/CD
+- Enabled sccache for maturin builds (faster CI compilation)
+- Added ruff format check to CI pipeline
+
+### Security
+- MockRow/MockRowBuilder now properly gated behind `test-utils` feature
+- Added SQL identifier length validation (127 char HANA limit)
+
 ## [0.1.0] - 2025-01-11
 
 Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
@@ -50,5 +75,6 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bug-ops/pyhdb-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]
@@ -41,7 +41,7 @@ criterion = "0.8"
 deadpool = { version = "0.12", default-features = false }
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.0" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.1" }
 lru = "0.16"
 parking_lot = "0.12.5"
 pyo3 = "0.27"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ High-performance Python driver for SAP HANA with native Arrow support.
 [![Crates.io](https://img.shields.io/crates/v/hdbconnect-arrow.svg)](https://crates.io/crates/hdbconnect-arrow)
 [![docs.rs](https://img.shields.io/docsrs/hdbconnect-arrow)](https://docs.rs/hdbconnect-arrow)
 [![PyPI](https://img.shields.io/pypi/v/pyhdb_rs.svg)](https://pypi.org/project/pyhdb_rs/)
+[![Python](https://img.shields.io/pypi/pyversions/pyhdb_rs)](https://pypi.org/project/pyhdb_rs)
 [![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://github.com/bug-ops/pyhdb-rs)
 [![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue.svg)](LICENSE-APACHE)
 
@@ -21,26 +22,17 @@ High-performance Python driver for SAP HANA with native Arrow support.
 
 ## Installation
 
-### From PyPI
-
 ```bash
 pip install pyhdb_rs
 ```
 
-### With optional dependencies
+With optional dependencies:
 
 ```bash
-# For Polars integration
-pip install pyhdb_rs[polars]
-
-# For pandas integration
-pip install pyhdb_rs[pandas]
-
-# For async support
-pip install pyhdb_rs[async]
-
-# All optional dependencies
-pip install pyhdb_rs[all]
+pip install pyhdb_rs[polars]    # Polars integration
+pip install pyhdb_rs[pandas]    # pandas + PyArrow
+pip install pyhdb_rs[async]     # Async support
+pip install pyhdb_rs[all]       # All integrations
 ```
 
 > [!IMPORTANT]
@@ -50,13 +42,12 @@ pip install pyhdb_rs[all]
 
 ```bash
 git clone https://github.com/bug-ops/pyhdb-rs.git
-cd pyhdb-rs
+cd pyhdb-rs/python
 
 python -m venv .venv
-source .venv/bin/activate
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 pip install maturin
-cd python
 maturin develop
 ```
 
@@ -67,7 +58,7 @@ maturin develop
 ```python
 import pyhdb_rs
 
-conn = pyhdb_rs.connect("hdbsql://user:pass@host:30015")
+conn = pyhdb_rs.connect("hdbsql://USER:PASSWORD@HOST:30015")
 
 with conn.cursor() as cursor:
     cursor.execute("SELECT * FROM USERS WHERE active = ?", [True])
@@ -88,10 +79,9 @@ conn.close()
 ```python
 import pyhdb_rs.polars as hdb
 
-# Read directly into Polars DataFrame (zero-copy)
 df = hdb.read_hana(
     "SELECT * FROM sales WHERE year = 2024",
-    "hdbsql://analyst:secret@hana.corp:39017"
+    "hdbsql://USER:PASSWORD@HOST:39017"
 )
 
 print(df.head())
@@ -105,7 +95,7 @@ Or using the connection object:
 ```python
 import pyhdb_rs
 
-conn = pyhdb_rs.connect("hdbsql://user:pass@host:30015")
+conn = pyhdb_rs.connect("hdbsql://USER:PASSWORD@HOST:30015")
 
 # Get as Polars DataFrame
 df = conn.execute_polars("SELECT * FROM products")
@@ -125,7 +115,7 @@ import pyhdb_rs.pandas as hdb
 
 df = hdb.read_hana(
     "SELECT * FROM sales",
-    "hdbsql://user:pass@host:39017"
+    "hdbsql://USER:PASSWORD@HOST:39017"
 )
 
 print(df.head())
@@ -145,7 +135,7 @@ import asyncio
 from pyhdb_rs.aio import connect
 
 async def main():
-    async with await connect("hdbsql://user:pass@host:30015") as conn:
+    async with await connect("hdbsql://USER:PASSWORD@HOST:30015") as conn:
         df = await conn.execute_polars("SELECT * FROM sales")
         print(df)
 
@@ -160,7 +150,7 @@ from pyhdb_rs.aio import create_pool
 
 async def main():
     pool = create_pool(
-        "hdbsql://user:pass@host:30015",
+        "hdbsql://USER:PASSWORD@HOST:30015",
         max_size=10,
         connection_timeout=30
     )
@@ -186,7 +176,7 @@ async def fetch_data(pool, table: str):
         return await conn.execute_polars(f"SELECT * FROM {table}")
 
 async def main():
-    pool = create_pool("hdbsql://user:pass@host:30015", max_size=5)
+    pool = create_pool("hdbsql://USER:PASSWORD@HOST:30015", max_size=5)
 
     # Run multiple queries concurrently
     results = await asyncio.gather(
@@ -203,7 +193,7 @@ asyncio.run(main())
 ## Connection URL format
 
 ```
-hdbsql://[user[:password]@]host[:port][/database][?options]
+hdbsql://[USER[:PASSWORD]@]HOST[:PORT][/DATABASE][?OPTIONS]
 ```
 
 Examples:

--- a/crates/hdbconnect-arrow/README.md
+++ b/crates/hdbconnect-arrow/README.md
@@ -1,6 +1,6 @@
 # hdbconnect-arrow
 
-[![Crates.io](https://img.shields.io/crates/v/hdbconnect-arrow.svg)](https://crates.io/crates/hdbconnect-arrow)
+[![Crates.io](https://img.shields.io/crates/v/hdbconnect-arrow)](https://crates.io/crates/hdbconnect-arrow)
 [![docs.rs](https://img.shields.io/docsrs/hdbconnect-arrow)](https://docs.rs/hdbconnect-arrow)
 [![codecov](https://codecov.io/gh/bug-ops/pyhdb-rs/graph/badge.svg?token=75RR61N6FI&flag=hdbconnect-arrow)](https://codecov.io/gh/bug-ops/pyhdb-rs)
 [![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://github.com/bug-ops/pyhdb-rs)
@@ -77,10 +77,9 @@ let arrow_field = hana_field_to_arrow(&hana_field_metadata);
 
 ```rust,ignore
 use hdbconnect_arrow::BatchConfig;
+use std::num::NonZeroUsize;
 
-let config = BatchConfig::builder()
-    .batch_size(10_000)
-    .build();
+let config = BatchConfig::new(NonZeroUsize::new(10_000).unwrap());
 ```
 
 ## Features
@@ -89,12 +88,16 @@ Enable optional features in `Cargo.toml`:
 
 ```toml
 [dependencies]
-hdbconnect-arrow = { version = "0.1", features = ["async"] }
+hdbconnect-arrow = { version = "0.1", features = ["async", "test-utils"] }
 ```
 
 | Feature | Description | Default |
 |---------|-------------|---------|
 | `async` | Async support via `hdbconnect_async` | No |
+| `test-utils` | Expose `MockRow`/`MockRowBuilder` for testing | No |
+
+> [!TIP]
+> Enable `test-utils` in dev-dependencies for unit testing without a HANA connection.
 
 ## Type mapping
 
@@ -121,17 +124,35 @@ hdbconnect-arrow = { version = "0.1", features = ["async"] }
 
 ### Core types
 
-- **`HanaBatchProcessor`** - Converts HANA rows to Arrow `RecordBatch` with configurable batch sizes
-- **`BatchConfig`** - Configuration for batch processing (size, memory limits)
-- **`SchemaMapper`** - Maps HANA result set metadata to Arrow schemas
-- **`BuilderFactory`** - Creates appropriate Arrow array builders for HANA types
+- **`HanaBatchProcessor`** — Converts HANA rows to Arrow `RecordBatch` with configurable batch sizes
+- **`BatchConfig`** — Configuration for batch processing (uses `NonZeroUsize` for type-safe batch size)
+- **`SchemaMapper`** — Maps HANA result set metadata to Arrow schemas
+- **`BuilderFactory`** — Creates appropriate Arrow array builders for HANA types
+- **`TypeCategory`** — Centralized HANA type classification enum
 
 ### Traits
 
-- **`HanaCompatibleBuilder`** - Trait for Arrow builders that accept HANA values
-- **`FromHanaValue`** - Sealed trait for type-safe value conversion
-- **`BatchProcessor`** - Core batch processing interface
-- **`LendingBatchIterator`** - GAT-based streaming iterator for large result sets
+- **`HanaCompatibleBuilder`** — Trait for Arrow builders that accept HANA values
+- **`FromHanaValue`** — Sealed trait for type-safe value conversion
+- **`BatchProcessor`** — Core batch processing interface
+- **`LendingBatchIterator`** — GAT-based streaming iterator for large result sets
+- **`RowLike`** — Row abstraction for testing without HANA connection
+
+### Test utilities
+
+When `test-utils` feature is enabled:
+
+```rust,ignore
+use hdbconnect_arrow::{MockRow, MockRowBuilder};
+
+let row = MockRowBuilder::new()
+    .push_i64(42)
+    .push_string("test")
+    .push_null()
+    .build();
+
+// Use with HanaBatchProcessor for unit tests
+```
 
 ### Error handling
 
@@ -143,6 +164,7 @@ fn convert_data() -> Result<()> {
     // - Type mismatches
     // - Decimal overflow
     // - Schema incompatibilities
+    // - Invalid batch configuration
     Ok(())
 }
 ```
@@ -152,7 +174,7 @@ fn convert_data() -> Result<()> {
 This crate is part of the [pyhdb-rs](https://github.com/bug-ops/pyhdb-rs) workspace, providing the Arrow integration layer for the Python SAP HANA driver.
 
 Related crates:
-- [`hdbconnect-py`](https://github.com/bug-ops/pyhdb-rs/tree/main/crates/hdbconnect-py) - PyO3 bindings exposing Arrow data to Python
+- [`hdbconnect-py`](https://github.com/bug-ops/pyhdb-rs/tree/main/crates/hdbconnect-py) — PyO3 bindings exposing Arrow data to Python
 
 ## MSRV policy
 

--- a/crates/hdbconnect-py/README.md
+++ b/crates/hdbconnect-py/README.md
@@ -1,13 +1,109 @@
 # hdbconnect-py
 
-[![PyPI](https://img.shields.io/pypi/v/pyhdb_rs.svg)](https://pypi.org/project/pyhdb_rs/)
+[![PyPI](https://img.shields.io/pypi/v/pyhdb_rs)](https://pypi.org/project/pyhdb_rs/)
+[![Python](https://img.shields.io/pypi/pyversions/pyhdb_rs)](https://pypi.org/project/pyhdb_rs)
 [![codecov](https://codecov.io/gh/bug-ops/pyhdb-rs/graph/badge.svg?token=75RR61N6FI&flag=hdbconnect-py)](https://codecov.io/gh/bug-ops/pyhdb-rs)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://github.com/bug-ops/pyhdb-rs)
+[![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue.svg)](LICENSE-APACHE)
 
-Python bindings for SAP HANA via hdbconnect.
+PyO3 bindings for SAP HANA via hdbconnect, exposing the native Rust driver to Python with zero-copy Arrow data transfer.
 
 ## Features
 
-- DB-API 2.0 compliant Connection and Cursor
-- Zero-copy Arrow data transfer via PyCapsule Interface
-- Native Polars/pandas integration
+- **DB-API 2.0 compliant** — `Connection` and `Cursor` classes following PEP 249
+- **Zero-copy Arrow** — Data transfer via PyCapsule Interface (PEP 3118)
+- **Native integrations** — Direct Polars/pandas support
+- **Async support** — Non-blocking operations with connection pooling
+- **Type-safe** — Full Python type hints via inline stubs
 
+## Architecture
+
+This crate provides the `pyhdb_rs._core` extension module:
+
+```
+Python Application
+        ↓
+pyhdb_rs (Python package)
+  └── _core (this crate)
+        ↓
+hdbconnect-arrow
+        ↓
+hdbconnect (Rust)
+        ↓
+SAP HANA Database
+```
+
+## Exposed types
+
+### Synchronous API
+
+- `Connection` — Database connection with context manager support
+- `Cursor` — Query execution with parameter binding
+- `RecordBatchReader` — Arrow data streaming via PyCapsule
+
+### Async API
+
+- `AsyncConnection` — Async database connection
+- `AsyncCursor` — Async query execution
+- `ConnectionPool` — Managed connection pool with configurable size
+
+### Exceptions
+
+DB-API 2.0 exception hierarchy:
+
+- `Error` — Base exception
+  - `DatabaseError` — Database-related errors
+    - `DataError` — Data processing errors
+    - `OperationalError` — Connection/transaction errors
+    - `IntegrityError` — Constraint violations
+    - `InternalError` — Internal database errors
+    - `ProgrammingError` — SQL syntax errors
+    - `NotSupportedError` — Unsupported operations
+  - `InterfaceError` — Driver interface errors
+- `Warning` — Non-fatal warnings
+
+## Building
+
+```bash
+cd crates/hdbconnect-py
+
+# Development build
+maturin develop
+
+# Release build
+maturin build --release
+```
+
+> [!NOTE]
+> Uses PyO3 ABI3 for Python 3.11+ compatibility from a single wheel.
+
+## Testing
+
+```bash
+# Rust unit tests
+cargo nextest run -p hdbconnect-py
+
+# Python integration tests (requires wheel)
+cd python
+maturin develop
+pytest
+```
+
+## Part of pyhdb-rs
+
+This crate is part of the [pyhdb-rs](https://github.com/bug-ops/pyhdb-rs) workspace.
+
+Related crates:
+- [`hdbconnect-arrow`](https://github.com/bug-ops/pyhdb-rs/tree/main/crates/hdbconnect-arrow) — Arrow conversion layer
+
+Python package:
+- [`pyhdb_rs`](https://pypi.org/project/pyhdb_rs/) — Published Python package on PyPI
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.1.0"
+version = "0.1.1"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 0.1.1
- Update CHANGELOG with v0.1.1 changes
- Refresh all README files with improved documentation

## Changes in v0.1.1

### Architecture
- Refactored Python utilities into shared `_utils.py` module
- Introduced `TypeCategory` enum for centralized HANA type classification
- Added `NonZeroUsize` for type-safe batch size configuration
- Implemented `RowLike` trait abstraction for testing
- Added `MockRow`/`MockRowBuilder` test utilities (behind `test-utils` feature)

### Testing
- Added comprehensive unit tests for `_utils.py` module (25 tests)
- Improved test coverage for PyO3 bindings

### CI/CD
- Enabled sccache for maturin builds
- Added ruff format check to CI pipeline

### Security
- MockRow/MockRowBuilder now properly gated behind `test-utils` feature
- Added SQL identifier length validation (127 char HANA limit)

## Test plan

- [ ] CI passes
- [ ] Version numbers consistent across manifests
- [ ] README renders correctly on GitHub