### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-01-11
+
+### Performance
+
+#### Decimal Conversion
+- Replaced string-based decimal parsing with direct `BigDecimal::as_bigint_and_exponent()`
+- Eliminates ~100K heap allocations per 100K decimal values
+- ~2x faster decimal conversion for bulk workloads
+
+#### Arrow Builder Optimization
+- Builder reuse at batch boundaries (Arrow builders reset after `finish()`)
+- Removed unnecessary factory field from `HanaBatchProcessor`
+- Added `Vec::with_capacity()` hints in `create_builders_for_schema()`
+- 10-15% throughput improvement for batch processing
+
+#### PyO3 Optimizations
+- Thread-local caching for Python datetime/decimal types
+- Eliminates repeated `py.import()` and `getattr()` calls per row
+- Safe `RefCell` pattern with `try_borrow_mut()` for reentrancy protection
+
+#### Build
+- Added optimized release profile with LTO (`lto = "fat"`)
+- Single codegen unit for maximum optimization
+- Strip symbols for smaller binary size
+- Added `bench` and `release-with-debug` profiles
+
+### Added
+
+- Comprehensive Criterion benchmark suite for Arrow conversions
+- Benchmarks for Int32, Int64, String, Boolean, Float64, Decimal types
+- Mixed schema and batch size comparison benchmarks
+- Builder creation and null handling benchmarks
+
+### Changed
+
+- CI now excludes `hdbconnect-py` from cargo test (PyO3 abi3 requires Python at runtime)
+
 ## [0.1.1] - 2026-01-11
 
 ### Changed
@@ -75,6 +112,7 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bug-ops/pyhdb-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.85"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]
@@ -42,7 +42,7 @@ criterion = "0.8"
 deadpool = { version = "0.12", default-features = false }
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.1" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.2" }
 lru = "0.16"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -225,8 +225,13 @@ pyhdb-rs is designed for high-performance data access:
 - **Rust core**: All heavy lifting happens in compiled Rust code
 - **Connection pooling**: Async pool with configurable size for high-concurrency workloads
 - **Batch processing**: Efficient handling of large result sets via streaming
+- **Optimized conversions**: Direct BigInt arithmetic for decimals, builder reuse at batch boundaries
+- **Type caching**: Thread-local Python type references minimize FFI overhead
 
 Benchmarks show 2x+ performance improvement over hdbcli for bulk reads.
+
+> [!TIP]
+> For maximum performance, use `execute_polars()` or `execute_arrow()` methods which provide zero-copy data transfer.
 
 ## MSRV policy
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,6 @@
 
 [![PyPI](https://img.shields.io/pypi/v/pyhdb_rs)](https://pypi.org/project/pyhdb_rs)
 [![Python](https://img.shields.io/pypi/pyversions/pyhdb_rs)](https://pypi.org/project/pyhdb_rs)
-[![Downloads](https://img.shields.io/pypi/dm/pyhdb_rs)](https://pypi.org/project/pyhdb_rs)
 [![CI](https://img.shields.io/github/actions/workflow/status/bug-ops/pyhdb-rs/ci.yml)](https://github.com/bug-ops/pyhdb-rs/actions)
 [![License](https://img.shields.io/pypi/l/pyhdb_rs)](https://github.com/bug-ops/pyhdb-rs/blob/main/LICENSE-MIT)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.1.1"
+version = "0.1.2"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

Patch release with performance optimizations.

### Changes
- Bump version to 0.1.2 in all manifests
- Update main README with performance improvements
- Add CHANGELOG entry for 0.1.2

### Performance Improvements (from previous PR)
- Decimal conversion: ~2x faster with direct BigInt arithmetic
- Arrow builders: 10-15% throughput improvement with builder reuse
- PyO3: Thread-local type caching reduces FFI overhead
- Build: LTO and optimized release profile