### PR TITLE
chore: release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-01-13
+
+### Added
+
+- Linux musl support (x86_64, aarch64) for Alpine and static builds
+- Jupyter notebook examples in `examples/notebooks/`
+  - Quickstart guide
+  - Advanced Polars analytics
+  - Streaming large datasets
+  - Performance comparison vs hdbcli
+
 ### Changed
 
 - **BREAKING**: Minimum Supported Rust Version raised from 1.85 to 1.88
 - Refactored nested if-let patterns to use let chains (Rust 1.88 feature)
+- README updated with platform support table and uv commands
+- Installation examples now use uv instead of pip
+
+### CI/CD
+
+- Expanded build matrix to 9 cross-platform targets
+- Added macOS and Windows to Python test matrix (9 combinations)
+- Enabled sccache with GitHub Actions cache backend
+- Added `generate-import-lib` feature for PyO3 cross-compilation
+- Improved caching with `uv sync --frozen` and cache suffixes
 
 ## [0.1.2] - 2026-01-11
 
@@ -117,7 +138,8 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/bug-ops/pyhdb-rs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bug-ops/pyhdb-rs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.1.2"
+version = "0.1.3"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]
@@ -42,7 +42,7 @@ criterion = "0.8"
 deadpool = { version = "0.12", default-features = false }
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.2" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.1.3" }
 lru = "0.16"
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -23,20 +23,29 @@ High-performance Python driver for SAP HANA with native Arrow support.
 ## Installation
 
 ```bash
-pip install pyhdb_rs
+uv pip install pyhdb_rs
 ```
 
 With optional dependencies:
 
 ```bash
-pip install pyhdb_rs[polars]    # Polars integration
-pip install pyhdb_rs[pandas]    # pandas + PyArrow
-pip install pyhdb_rs[async]     # Async support
-pip install pyhdb_rs[all]       # All integrations
+uv pip install pyhdb_rs[polars]    # Polars integration
+uv pip install pyhdb_rs[pandas]    # pandas + PyArrow
+uv pip install pyhdb_rs[async]     # Async support
+uv pip install pyhdb_rs[all]       # All integrations
 ```
 
 > [!IMPORTANT]
 > Requires Python 3.11 or later.
+
+### Platform support
+
+| Platform | Architectures |
+|----------|---------------|
+| Linux (glibc) | x86_64, aarch64 |
+| Linux (musl) | x86_64, aarch64 |
+| macOS | x86_64, aarch64 |
+| Windows | x86_64 |
 
 ### From source
 
@@ -44,11 +53,11 @@ pip install pyhdb_rs[all]       # All integrations
 git clone https://github.com/bug-ops/pyhdb-rs.git
 cd pyhdb-rs/python
 
-python -m venv .venv
+uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-pip install maturin
-maturin develop
+uv pip install maturin
+maturin develop --release
 ```
 
 ## Quick start
@@ -237,6 +246,15 @@ Benchmarks show 2x+ performance improvement over hdbcli for bulk reads.
 
 > [!NOTE]
 > Minimum Supported Rust Version: **1.88**. MSRV increases are minor version bumps.
+
+## Examples
+
+Interactive Jupyter notebooks are available in [`examples/notebooks/`](examples/notebooks/):
+
+- **01_quickstart** — Basic connection and DataFrame integration
+- **02_polars_analytics** — Advanced Polars analytics with LazyFrames
+- **03_streaming_large_data** — Memory-efficient large dataset processing
+- **04_performance_comparison** — Benchmarks vs hdbcli
 
 ## Repository
 

--- a/crates/hdbconnect-arrow/README.md
+++ b/crates/hdbconnect-arrow/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/hdbconnect-arrow)](https://crates.io/crates/hdbconnect-arrow)
 [![docs.rs](https://img.shields.io/docsrs/hdbconnect-arrow)](https://docs.rs/hdbconnect-arrow)
 [![codecov](https://codecov.io/gh/bug-ops/pyhdb-rs/graph/badge.svg?token=75RR61N6FI&flag=hdbconnect-arrow)](https://codecov.io/gh/bug-ops/pyhdb-rs)
-[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](https://github.com/bug-ops/pyhdb-rs)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://github.com/bug-ops/pyhdb-rs)
 [![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue.svg)](LICENSE-APACHE)
 
 Apache Arrow integration for the [hdbconnect](https://crates.io/crates/hdbconnect) SAP HANA driver, enabling zero-copy data transfer to analytics tools like Polars and pandas.
@@ -24,7 +24,7 @@ cargo add hdbconnect-arrow
 ```
 
 > [!IMPORTANT]
-> Requires Rust 1.85 or later.
+> Requires Rust 1.88 or later.
 
 ## Usage
 
@@ -179,7 +179,7 @@ Related crates:
 ## MSRV policy
 
 > [!NOTE]
-> Minimum Supported Rust Version: **1.85**. MSRV increases are minor version bumps.
+> Minimum Supported Rust Version: **1.88**. MSRV increases are minor version bumps.
 
 ## License
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.1.2"
+version = "0.1.3"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

Release 0.1.3 with cross-platform improvements and documentation updates.

### Version bumps

- `Cargo.toml`: 0.1.2 → 0.1.3
- `python/pyproject.toml`: 0.1.2 → 0.1.3
- MSRV badge: 1.85 → 1.88

### Documentation

- Add platform support table to README
- Update installation examples to use `uv` instead of `pip`
- Add Examples section linking to Jupyter notebooks
- Update `hdbconnect-arrow` README with MSRV 1.88

### CHANGELOG

Added entries for:
- Linux musl support (x86_64, aarch64)
- Jupyter notebook examples
- CI/CD improvements (9 targets, sccache, frozen deps)
- MSRV 1.88 with let chains

## Test plan

- [ ] CI passes
- [ ] Version numbers are consistent across manifests