### PR TITLE
docs: expand Arrow ecosystem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ Benchmarks show 2x+ performance improvement over hdbcli for bulk reads.
 > [!TIP]
 > For maximum performance, use `execute_polars()` or `execute_arrow()` methods which provide zero-copy data transfer.
 
+## Arrow ecosystem
+
+Data is exported in [Apache Arrow](https://arrow.apache.org/) format, enabling zero-copy interoperability with:
+
+- **DataFrames** — Polars, pandas, Vaex, Dask
+- **Query engines** — DataFusion, DuckDB, ClickHouse
+- **ML/AI** — Ray, Hugging Face Datasets, PyTorch
+- **Data lakes** — Delta Lake, Apache Iceberg, Lance
+- **Serialization** — Parquet, Arrow IPC (Feather)
+
+For Rust integration examples (DataFusion, DuckDB, Parquet export), see [`hdbconnect-arrow`](crates/hdbconnect-arrow/README.md).
+
 ## MSRV policy
 
 > [!NOTE]

--- a/crates/hdbconnect-arrow/README.md
+++ b/crates/hdbconnect-arrow/README.md
@@ -6,11 +6,25 @@
 [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue)](https://github.com/bug-ops/pyhdb-rs)
 [![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue.svg)](LICENSE-APACHE)
 
-Apache Arrow integration for the [hdbconnect](https://crates.io/crates/hdbconnect) SAP HANA driver, enabling zero-copy data transfer to analytics tools like Polars and pandas.
+Apache Arrow integration for the [hdbconnect](https://crates.io/crates/hdbconnect) SAP HANA driver. Converts HANA result sets to Arrow `RecordBatch` format, enabling zero-copy interoperability with the entire Arrow ecosystem.
+
+## Why Arrow?
+
+[Apache Arrow](https://arrow.apache.org/) is the universal columnar data format for analytics. By converting SAP HANA data to Arrow, you unlock seamless integration with:
+
+| Category | Tools |
+|----------|-------|
+| **DataFrames** | Polars, pandas, Vaex, Dask |
+| **Query engines** | DataFusion, DuckDB, ClickHouse, Ballista |
+| **ML/AI** | Ray, Hugging Face Datasets, PyTorch, TensorFlow |
+| **Data lakes** | Delta Lake, Apache Iceberg, Lance |
+| **Visualization** | Perspective, Graphistry, Falcon |
+| **Languages** | Rust, Python, R, Julia, Go, Java, C++ |
+
+> [!TIP]
+> Arrow's columnar format enables vectorized processing — operations run 10-100x faster than row-by-row iteration.
 
 ## Installation
-
-Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -82,6 +96,108 @@ use std::num::NonZeroUsize;
 let config = BatchConfig::new(NonZeroUsize::new(10_000).unwrap());
 ```
 
+## Ecosystem integration
+
+<details>
+<summary><strong>DataFusion</strong> — SQL queries on Arrow data</summary>
+
+Query HANA data with SQL using [Apache DataFusion](https://datafusion.apache.org/):
+
+```rust,ignore
+use datafusion::prelude::*;
+
+let batches = collect_batches_from_hana(result_set)?;
+let ctx = SessionContext::new();
+ctx.register_batch("hana_data", batches[0].clone())?;
+
+let df = ctx.sql("SELECT * FROM hana_data WHERE amount > 1000").await?;
+df.show().await?;
+```
+
+</details>
+
+<details>
+<summary><strong>DuckDB</strong> — analytical queries</summary>
+
+Load Arrow data directly into [DuckDB](https://duckdb.org/):
+
+```rust,ignore
+use duckdb::{Connection, arrow::record_batch_to_duckdb};
+
+let conn = Connection::open_in_memory()?;
+conn.register_arrow("sales", batches)?;
+
+let mut stmt = conn.prepare("SELECT region, SUM(amount) FROM sales GROUP BY region")?;
+let result = stmt.query_arrow([])?;
+```
+
+</details>
+
+<details>
+<summary><strong>Polars</strong> — zero-copy DataFrame</summary>
+
+Convert to [Polars](https://pola.rs/) DataFrame:
+
+```rust,ignore
+use polars::prelude::*;
+
+let batch = processor.flush()?.unwrap();
+let df = DataFrame::try_from(batch)?;
+
+let result = df.lazy()
+    .filter(col("status").eq(lit("active")))
+    .group_by([col("region")])
+    .agg([col("amount").sum()])
+    .collect()?;
+```
+
+</details>
+
+<details>
+<summary><strong>Arrow IPC / Parquet</strong> — serialization</summary>
+
+Serialize Arrow data for storage or network transfer:
+
+```rust,ignore
+use arrow_ipc::writer::FileWriter;
+use parquet::arrow::ArrowWriter;
+use std::fs::File;
+
+// Arrow IPC (Feather) format
+let file = File::create("data.arrow")?;
+let mut writer = FileWriter::try_new(file, &schema)?;
+writer.write(&batch)?;
+writer.finish()?;
+
+// Parquet format
+let file = File::create("data.parquet")?;
+let mut writer = ArrowWriter::try_new(file, schema.clone(), None)?;
+writer.write(&batch)?;
+writer.close()?;
+```
+
+</details>
+
+<details>
+<summary><strong>Python interop</strong> — PyCapsule zero-copy</summary>
+
+Export Arrow data to Python without copying (requires `pyo3`):
+
+```rust,ignore
+use pyo3_arrow::PyArrowType;
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn get_hana_data(py: Python<'_>) -> PyResult<PyArrowType<RecordBatch>> {
+    let batch = fetch_from_hana()?;
+    Ok(PyArrowType(batch))
+}
+
+// Python: df = pl.from_arrow(get_hana_data())
+```
+
+</details>
+
 ## Features
 
 Enable optional features in `Cargo.toml`:
@@ -100,6 +216,9 @@ hdbconnect-arrow = { version = "0.1", features = ["async", "test-utils"] }
 > Enable `test-utils` in dev-dependencies for unit testing without a HANA connection.
 
 ## Type mapping
+
+<details>
+<summary>HANA → Arrow type conversion table</summary>
 
 | HANA Type | Arrow Type | Notes |
 |-----------|------------|-------|
@@ -120,9 +239,12 @@ hdbconnect-arrow = { version = "0.1", features = ["async", "test-utils"] }
 | BOOLEAN | Boolean | |
 | GEOMETRY, POINT | Binary | WKB format |
 
+</details>
+
 ## API overview
 
-### Core types
+<details>
+<summary><strong>Core types</strong></summary>
 
 - **`HanaBatchProcessor`** — Converts HANA rows to Arrow `RecordBatch` with configurable batch sizes
 - **`BatchConfig`** — Configuration for batch processing (uses `NonZeroUsize` for type-safe batch size)
@@ -130,7 +252,10 @@ hdbconnect-arrow = { version = "0.1", features = ["async", "test-utils"] }
 - **`BuilderFactory`** — Creates appropriate Arrow array builders for HANA types
 - **`TypeCategory`** — Centralized HANA type classification enum
 
-### Traits
+</details>
+
+<details>
+<summary><strong>Traits</strong></summary>
 
 - **`HanaCompatibleBuilder`** — Trait for Arrow builders that accept HANA values
 - **`FromHanaValue`** — Sealed trait for type-safe value conversion
@@ -138,7 +263,10 @@ hdbconnect-arrow = { version = "0.1", features = ["async", "test-utils"] }
 - **`LendingBatchIterator`** — GAT-based streaming iterator for large result sets
 - **`RowLike`** — Row abstraction for testing without HANA connection
 
-### Test utilities
+</details>
+
+<details>
+<summary><strong>Test utilities</strong></summary>
 
 When `test-utils` feature is enabled:
 
@@ -150,11 +278,12 @@ let row = MockRowBuilder::new()
     .push_string("test")
     .push_null()
     .build();
-
-// Use with HanaBatchProcessor for unit tests
 ```
 
-### Error handling
+</details>
+
+<details>
+<summary><strong>Error handling</strong></summary>
 
 ```rust,ignore
 use hdbconnect_arrow::{ArrowConversionError, Result};
@@ -169,12 +298,33 @@ fn convert_data() -> Result<()> {
 }
 ```
 
+</details>
+
+## Performance
+
+The crate is optimized for high-throughput data transfer:
+
+- **Zero-copy conversion** — Arrow builders write directly to memory without intermediate allocations
+- **Batch processing** — Configurable batch sizes to balance memory usage and throughput
+- **Decimal optimization** — Direct BigInt arithmetic avoids string parsing overhead
+- **Builder reuse** — Builders reset between batches, eliminating repeated allocations
+
+> [!NOTE]
+> For large result sets, use `LendingBatchIterator` to stream data with constant memory usage.
+
 ## Part of pyhdb-rs
 
 This crate is part of the [pyhdb-rs](https://github.com/bug-ops/pyhdb-rs) workspace, providing the Arrow integration layer for the Python SAP HANA driver.
 
 Related crates:
 - [`hdbconnect-py`](https://github.com/bug-ops/pyhdb-rs/tree/main/crates/hdbconnect-py) — PyO3 bindings exposing Arrow data to Python
+
+## Resources
+
+- [Apache Arrow](https://arrow.apache.org/) — Official Arrow project
+- [Arrow Rust](https://docs.rs/arrow) — Rust implementation
+- [DataFusion](https://datafusion.apache.org/) — Query engine built on Arrow
+- [Powered by Arrow](https://arrow.apache.org/powered_by/) — Projects using Arrow
 
 ## MSRV policy
 


### PR DESCRIPTION
## Summary

Expand documentation to showcase the broader Arrow ecosystem integration.

### hdbconnect-arrow README

- Add **Why Arrow?** section with ecosystem tools table
- Add **Ecosystem integration** section with collapsible examples:
  - DataFusion SQL queries
  - DuckDB analytical queries
  - Polars DataFrame conversion
  - Arrow IPC / Parquet serialization
  - Python interop via PyCapsule
- Add **Performance** section
- Add **Resources** section with Arrow ecosystem links
- Use `<details>` tags for lengthy sections

### Main README

- Add **Arrow ecosystem** section listing supported tools by category
- Reference `hdbconnect-arrow` crate for Rust integration details

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Collapsible sections expand/collapse properly