### PR TITLE
ci: reduce wheel artifact retention to 3 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
         with:
           name: wheels-${{ matrix.target }}
           path: python/dist/*.whl
+          retention-days: 3
 
   coverage-rust:
     name: Coverage Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: wheels-${{ matrix.target }}
           path: python/dist/*.whl
+          retention-days: 3
 
   build-sdist:
     name: Build source distribution
@@ -93,6 +94,7 @@ jobs:
         with:
           name: sdist
           path: python/dist/*.tar.gz
+          retention-days: 3
 
   publish-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Summary

Reduce artifact retention from 90 days (default) to 3 days.

After CI/release completes, intermediate artifacts aren't needed:
- CI wheels are for debugging only
- Release wheels are published to PyPI and GitHub Release

## Changes

| Workflow | Artifact | Retention |
|----------|----------|-----------|
| `ci.yml` | wheels | 3 days |
| `release.yml` | wheels | 3 days |
| `release.yml` | sdist | 3 days |