### PR TITLE
refactor(cursor): migrate from deprecated downcast to cast

### DIFF
--- a/crates/hdbconnect-py/src/cursor/wrapper.rs
+++ b/crates/hdbconnect-py/src/cursor/wrapper.rs
@@ -362,11 +362,8 @@ enum SerializableValue {
 }
 
 /// Convert Python parameters (tuple/list) to serializable values.
-// PySequence::downcast is deprecated in PyO3 0.23+ (use extract::<PySequence>() instead).
-// Keeping downcast for now as it still works and the migration is non-trivial.
-#[allow(deprecated)]
 fn convert_to_serializable(params: &Bound<'_, PyAny>) -> PyResult<Vec<SerializableValue>> {
-    let sequence: &Bound<'_, PySequence> = params.downcast()?;
+    let sequence = params.cast::<PySequence>()?;
     let len = sequence.len()?;
     let mut result = Vec::with_capacity(len);
 
@@ -380,10 +377,8 @@ fn convert_to_serializable(params: &Bound<'_, PyAny>) -> PyResult<Vec<Serializab
 }
 
 /// Convert sequence of Python parameter tuples/lists to batch serializable values.
-// See convert_to_serializable for deprecation note.
-#[allow(deprecated)]
 fn convert_to_serializable_batch(seq: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<SerializableValue>>> {
-    let sequence: &Bound<'_, PySequence> = seq.downcast()?;
+    let sequence = seq.cast::<PySequence>()?;
     let len = sequence.len()?;
     let mut result = Vec::with_capacity(len);
 


### PR DESCRIPTION
## Summary

Migrate from deprecated `PySequence::downcast()` to modern `Bound::cast()` API for PyO3 0.27+ compatibility.

## Problem

The cursor module used deprecated `PyAnyMethods::downcast()` API with suppression attributes:

```rust
#[allow(deprecated)]
fn convert_to_serializable(params: &Bound<'_, PyAny>) -> PyResult<Vec<SerializableValue>> {
    let sequence: &Bound<'_, PySequence> = params.downcast()?;
```

PyO3 0.27 deprecates `downcast()` in favor of `Bound::cast::<T>()` with turbofish syntax.

## Solution

Replace deprecated API with modern equivalent in two functions:

### convert_to_serializable (line 366)
```rust
// Before:
#[allow(deprecated)]
let sequence: &Bound<'_, PySequence> = params.downcast()?;

// After:
let sequence = params.cast::<PySequence>()?;
```

### convert_to_serializable_batch (line 381)
```rust
// Before:
#[allow(deprecated)]
let sequence: &Bound<'_, PySequence> = seq.downcast()?;

// After:
let sequence = seq.cast::<PySequence>()?;
```

## Changes

**File:** `crates/hdbconnect-py/src/cursor/wrapper.rs` (2 insertions, 7 deletions)

1. **Line 366** - Modern cast API:
   - `params.downcast::<PySequence>()?` → `params.cast::<PySequence>()?`
   
2. **Line 381** - Modern cast API:
   - `seq.downcast::<PySequence>()?` → `seq.cast::<PySequence>()?`

3. **Removed suppressions**:
   - 2× `#[allow(deprecated)]` attributes
   - 2× outdated deprecation comments

## Semantic Equivalence

Both `downcast()` and `cast()` are **semantically identical**:

1. **Type checking**: Both call `T::type_check()` → `PySequence_Check()` via Python C API
2. **Return type**: `Result<&Bound<'_, T>, PyDowncastError<'_>>`
3. **Success path**: Both use `cast_unchecked()` (zero-cost reference transmute)
4. **Error handling**: Identical `PyDowncastError` propagation
5. **Inlining**: Both methods marked `#[inline]` for compiler optimization

## Benefits

- ✅ **PyO3 0.27+ Compliance**: Eliminates deprecation warnings
- ✅ **Modern API**: Idiomatic turbofish pattern
- ✅ **Zero Performance Impact**: Identical implementation (validated)
- ✅ **Type Safety**: Runtime type checking maintained
- ✅ **Error Quality**: Error messages unchanged

## Verification

### Pre-commit Checks
- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace --all-features -- -D warnings` (0 warnings)
- ✅ `cargo check --workspace`
- ✅ `cargo deny check`
- ✅ `cargo nextest run` (397 tests passed)

### Multi-Agent Review
- ✅ **rust-architect**: Designed migration strategy (cast vs downcast analysis)
- ✅ **rust-developer**: Implemented migration (2 functions, 2 lines changed)
- ✅ **rust-performance-engineer**: Performance PASS (neutral - identical implementation)
- ✅ **rust-security-maintenance**: Security APPROVED (type safety maintained)
- ✅ **rust-testing-engineer**: Test coverage ADEQUATE (Python integration tests)
- ✅ **rust-code-reviewer**: Code review APPROVED (0 issues found)

## Technical Debt Addressed

Phase 5 (final phase) of technical debt elimination plan:
- **Item 3.5**: Deprecated API usage (cursor/wrapper.rs:367-368, 384-385)
- **Priority**: MEDIUM (deprecation warning)
- **Resolution**: Migrated to PyO3 0.27+ modern API

## Impact

- **Breaking changes**: None
- **API changes**: None (internal implementation only)
- **Performance**: Neutral (validated)
- **Security**: Maintained (validated)
- **Risk**: LOW (minimal change, identical semantics)