### PR TITLE
perf: fix temporal types regression with Box wrapping optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Better cache locality through contiguous memory layout in `Vec<BuilderEnum>`
   - New public API: `BuilderFactory::create_builder_enum()`, `BuilderEnum`, `BuilderKind`, `SchemaProfile`
 
+### Fixed
+
+- **Performance**: Box wrapping optimization for large `BuilderEnum` variants
+  - Wrapped 6 large variants (Decimal128, String, Binary builders) in `Box` to reduce enum size
+  - Improved cache locality for temporal and primitive types
+  - Eliminated temporal types performance regression from Phase 2 (-24% → <1%)
+  - Analytics workload gains maintained (+54-60%)
+  - Box indirection overhead negligible (<1%) on string/decimal operations
+
 ## [0.3.1] - 2026-01-29
 
 ### Removed


### PR DESCRIPTION
## Summary

Addresses performance regression in temporal types introduced in #47 through selective Box wrapping strategy:

- Wraps 6 large variants (Decimal128, String, Binary builders) in `Box` to reduce enum size
- Eliminates cache pressure on temporal and primitive types
- Restores temporal types performance from -24% regression to <1% variance
- Maintains analytics workload gains (+54-60% from #47)

## Benchmark Results

**Temporal types (fixed):**
- `date32_null_handling`: -19% → +0.17%
- `time64_null_handling`: -24% → +0.26%
- `timestamp_null_handling`: -24% → -0.18%

**Analytics workloads (maintained):**
- `analytics_workload/*`: +54-60% gain preserved
- `bulk_read_analytics/1m`: +55-56% gain preserved

**Trade-off:** Box indirection overhead <1% on string/decimal operations (negligible vs conversion cost ~100-1000ns)

## Test Plan

- [x] All 532 tests passing
- [x] Coverage: 94.17%
- [x] Clippy clean
- [x] Security audit passed
- [x] Code review approved
- [x] Quick benchmark verification confirms regression fix