### PR TITLE
release: v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-03-21
+
+### Changed
+
+- Version bump to 0.3.9
+
 ## [0.3.8] - 2026-03-17
 
 ### Fixed
@@ -754,7 +760,8 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.8...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.9...HEAD
+[0.3.9]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.5...v0.3.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ dhat = "0.3"
 futures = "0.3"
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.8" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.9" }
 jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 arc-swap = "1.8"
 lru = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.3.8"
+version = "0.3.9"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.3.8"
+version = "0.3.9"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

- Bump version from 0.3.8 to 0.3.9
- Update CHANGELOG.md with release section for 2026-03-21
- Sync version in python/pyproject.toml

## Checklist

- [x] Version updated in all manifests (Cargo.toml, pyproject.toml)
- [x] Cargo.lock updated
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass locally (1107 tests)
- [ ] Ready for tagging after merge