### PR TITLE
release: v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10] - 2026-04-26
+
+### Changed
+
+- Version bump to 0.3.10
+
 ## [0.3.9] - 2026-03-21
 
 ### Changed
@@ -760,7 +766,8 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.9...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.10...HEAD
+[0.3.10]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.6...v0.3.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-mcp"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.3.9"
+version = "0.3.10"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]
@@ -48,7 +48,7 @@ dhat = "0.3"
 futures = "0.3"
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.9" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.10" }
 jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 arc-swap = "1.9"
 lru = "0.16"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.3.9"
+version = "0.3.10"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

- Bump version from 0.3.9 to 0.3.10
- Update CHANGELOG.md with release section dated 2026-04-26
- Update `python/pyproject.toml` to 0.3.10

## Checklist

- [x] Version updated in all manifests (Cargo.toml, python/pyproject.toml)
- [x] Cargo.lock updated
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass locally
- [ ] Ready for tagging after merge