### PR TITLE
release: v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11] - 2026-05-26
+
+### Changed
+
+- **Dependencies**: Bump `tracing-opentelemetry` 0.32.1 → 0.33.0; align `opentelemetry`, `opentelemetry-otlp`, `opentelemetry_sdk` 0.31 → 0.32 (#147)
+- **Dependencies**: Bump `rmcp` 1.6.0 → 1.7.0, `metrics` 0.24.5 → 0.24.6, `tower-http` 0.6.10 → 0.6.11 (#145)
+- **Dependencies**: Bump `serde_json` 1.0.149 → 1.0.150 (#146)
+- **Dependencies**: Bump `reqwest` (#138), `axum` 0.8.9, `tokio` 1.52.1, `lru` 0.16.3 → 0.18.0 (#137), `clap`
+- **Dependencies**: Bump rust-minor-patch group (8 packages) (#139, #141)
+- **CI**: Bump `actions/dependency-review-action` (#140), `mozilla-actions/sccache-action` (#135)
+- **Python dev**: Update `pyarrow` requirement in `/python` (#134)
+
 ## [0.3.10] - 2026-04-26
 
 ### Changed
@@ -766,7 +778,8 @@ Initial release of pyhdb-rs — high-performance Python driver for SAP HANA.
 - Build provenance attestations for all release artifacts
 - Dependency auditing with cargo-deny
 
-[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.10...HEAD
+[Unreleased]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.11...HEAD
+[0.3.11]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/bug-ops/pyhdb-rs/compare/v0.3.7...v0.3.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-arrow"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-mcp"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "hdbconnect-py"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 rust-version = "1.88"
-version = "0.3.10"
+version = "0.3.11"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/bug-ops/pyhdb-rs"
 authors = ["Andrei G <andrei.g@my.com>"]
@@ -48,7 +48,7 @@ dhat = "0.3"
 futures = "0.3"
 hdbconnect = "0.32"
 hdbconnect_async = "0.32"
-hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.10" }
+hdbconnect-arrow = { path = "crates/hdbconnect-arrow", version = "0.3.11" }
 jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 arc-swap = "1.9"
 lru = "0.18"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyhdb_rs"
-version = "0.3.10"
+version = "0.3.11"
 description = "High-performance Python driver for SAP HANA with native Arrow support"
 readme = "README.md"
 license = { text = "Apache-2.0 OR MIT" }


### PR DESCRIPTION
## Summary

- Bump version from 0.3.10 to 0.3.11
- Update CHANGELOG.md with release notes for all dependency updates since 0.3.10
- Sync version in `python/pyproject.toml`

## Changes since 0.3.10

All changes are dependency updates:

- `tracing-opentelemetry` 0.32.1 → 0.33.0 (fixes deadlock when entering a span); aligned `opentelemetry*` 0.31 → 0.32
- `rmcp` 1.6.0 → 1.7.0, `metrics` 0.24.5 → 0.24.6, `tower-http` 0.6.10 → 0.6.11
- `serde_json` 1.0.149 → 1.0.150, `reqwest`, `axum` 0.8.9, `tokio` 1.52.1, `lru` 0.16.3 → 0.18.0
- Rust minor-patch group updates (#139, #141)
- CI: `actions/dependency-review-action`, `mozilla-actions/sccache-action`
- Python dev: `pyarrow` requirement update

## Checklist

- [x] Version updated in all manifests (`Cargo.toml`, `python/pyproject.toml`)
- [x] `Cargo.lock` updated
- [x] CHANGELOG.md has release section with date
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace --all-features -- -D warnings` passes
- [x] `cargo nextest run` passes (1107 tests)
- [ ] Ready for tagging after merge